### PR TITLE
Removed a function and some comments.

### DIFF
--- a/CSharpPracticeApp/AWSServiceFactory.cs
+++ b/CSharpPracticeApp/AWSServiceFactory.cs
@@ -6,9 +6,6 @@ using System.Threading.Tasks;
 
 namespace CSharpPracticeApp
 {
-    // This is an implementation of the factory design pattern, one of the most used design patterns.
-    // This design pattern allows us to create objects without exposing the creation logic to the client.
-    // In this example, we are creating AWSServers at a very high level.
     public class AWSServiceFactory
     {
         public IAWSServer GetAWSServer(String serverType)

--- a/UnitTestPractice/AWSServerTests.cs
+++ b/UnitTestPractice/AWSServerTests.cs
@@ -19,15 +19,5 @@ namespace UnitTestPractice
             EC2 ec2 = new EC2();
             CollectionAssert.AreEqual(expectedResult, ec2.ProcessTasks(serverInput, tasksInput));
         }
-
-        [TestMethod]
-        public void ProcessTasksTest2()
-        {
-            int[] serverInput = { 5, 1, 4, 3, 2 };
-            int[] tasksInput = { 2, 1, 2, 4, 5, 2, 1 };
-            int[] expectedResult = { 1, 4, 1, 4, 1, 3, 2 };
-            EC2 ec2 = new EC2();
-            CollectionAssert.AreEqual(expectedResult, ec2.ProcessTasks(serverInput, tasksInput));
-        }
     }
 }


### PR DESCRIPTION
We removed this test code because this test had an error. The comments were redundant.